### PR TITLE
Fix urlparse import under Python 3

### DIFF
--- a/env.py
+++ b/env.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from os import environ
-from urlparse import urlparse as _urlparse
-
+try:
+    from urllib.parse import urlparse as _urlparse
+except ImportError:
+    from urlparse import urlparse as _urlparse
 
 def lower_dict(d):
     """Lower cases string keys in given dict."""

--- a/env.py
+++ b/env.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     from urlparse import urlparse as _urlparse
 
+
 def lower_dict(d):
     """Lower cases string keys in given dict."""
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setuptools import setup
 
 setup(
     name='env',
-    version='0.1.0',
+    version='0.1.1',
     url='https://github.com/kennethreitz/env',
     license='BSD',
     author='Kenneth Reitz',


### PR DESCRIPTION
This PR fixes an `ImportError` being thrown under Python 3.