### PR TITLE
Misc package management configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include Makefile
+include tests.py
+include tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Adds setup.cfg to avoid missing --universal option when uploading wheel to pypi.
Adds MANIFEST.in to make sure all necessary files end up in source tarball via sdist.